### PR TITLE
Loosen ActiveSupport dependency to support Rails 8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,33 +2,37 @@ PATH
   remote: .
   specs:
     fsrs (0.9.0)
-      activesupport (~> 7.0)
+      activesupport (>= 7.0, < 9.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.2)
+    activesupport (8.0.0)
       base64
+      benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     ast (2.4.2)
     base64 (0.2.0)
-    bigdecimal (3.1.7)
-    concurrent-ruby (1.2.3)
+    benchmark (0.4.0)
+    bigdecimal (3.1.8)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     drb (2.2.1)
-    i18n (1.14.4)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    minitest (5.22.3)
-    mutex_m (0.2.0)
+    logger (1.6.2)
+    minitest (5.25.4)
     parallel (1.24.0)
     parser (3.3.1.0)
       ast (~> 2.4.1)
@@ -55,9 +59,11 @@ GEM
       rubocop (>= 1.61, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uri (1.0.2)
 
 PLATFORMS
   arm64-darwin-23

--- a/fsrs.gemspec
+++ b/fsrs.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
-  spec.add_dependency "activesupport", "~> 7.0"
+  spec.add_dependency "activesupport", ">= 7.0", "< 9.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
This PR updates the gem's version dependencies to allow compatibility with Rails 8. Specifically, it relaxes the ActiveSupport version constraint to include 8.x versions.

Previous dependency restrictions prevented the gem from working with Rails 8. This change maintains existing functionality while extending support to the new Rails version.