### PR TITLE
Fix `schedule_new_state` due date calculation

### DIFF
--- a/lib/fsrs/fsrs.rb
+++ b/lib/fsrs/fsrs.rb
@@ -241,9 +241,9 @@ module Fsrs
 
     def schedule_new_state(s, now)
       init_ds(s)
-      s.again.due = now + 60
-      s.hard.due = now + (5 * 60)
-      s.good.due = now + (10 * 60)
+      s.again.due = now + 60.seconds
+      s.hard.due = now + (5 * 60).seconds
+      s.good.due = now + (10 * 60).seconds
       easy_interval = next_interval(s.easy.stability)
       s.easy.scheduled_days = easy_interval
       s.easy.due = now + easy_interval.days


### PR DESCRIPTION
Previously used `DateTime + <Integer>`, which adds days, not seconds. This caused incorrect scheduling for cards rated "Again", "Hard", or "Good". The net effect pushed new cards (Learning) out 60 days instead of 60 seconds.