### PR TITLE
Fix new card learning due dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [0.9.2] - 2026-04-26
+
+- Fix new-card learning step due dates for Again, Hard, and Good ratings.
+- Add SimpleCov test coverage reporting.
+
 ## [0.9.1] - 2026-04-25
 
 - Allow ActiveSupport 8.x so the gem can be installed in Rails 8 applications.

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,11 @@ gemspec
 gem "irb"
 gem "rdoc"
 
-gem "minitest", "~> 5.16"
 gem "rake", "~> 13.0"
 gem "rubocop", "~> 1.21"
 gem "rubocop-minitest"
+
+group :test do
+  gem "minitest", "~> 5.16"
+  gem "simplecov", require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fsrs (0.9.1)
+    fsrs (0.9.2)
       activesupport (>= 7.0, < 9.0)
 
 GEM
@@ -26,6 +26,7 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     date (3.4.1)
+    docile (1.4.1)
     drb (2.2.3)
     erb (5.0.1)
     i18n (1.14.8)
@@ -79,6 +80,12 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     stringio (3.1.7)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -99,6 +106,7 @@ DEPENDENCIES
   rdoc
   rubocop (~> 1.21)
   rubocop-minitest
+  simplecov
 
 BUNDLED WITH
    2.5.9

--- a/lib/fsrs/fsrs.rb
+++ b/lib/fsrs/fsrs.rb
@@ -304,9 +304,9 @@ module Fsrs
     module NewState # rubocop:disable Style/Documentation
       def schedule_new_state(s, now)
         init_ds(s)
-        s.again.due = now + 60
-        s.hard.due = now + (5 * 60)
-        s.good.due = now + (10 * 60)
+        s.again.due = now + 1.minute
+        s.hard.due = now + 5.minutes
+        s.good.due = now + 10.minutes
         easy_interval = next_interval(s.easy.stability)
         s.easy.scheduled_days = easy_interval
         s.easy.due = now + easy_interval.days

--- a/lib/fsrs/version.rb
+++ b/lib/fsrs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Fsrs
-  VERSION = "0.9.1"
+  VERSION = "0.9.2"
 end

--- a/test/test_fsrs.rb
+++ b/test/test_fsrs.rb
@@ -82,4 +82,20 @@ class FSRSTest < Minitest::Test
     # card object's due datetime should be later than its last review
     assert card.due >= card.last_review
   end
+
+  def test_new_card_learning_steps_are_scheduled_in_minutes
+    scheduler = Fsrs::Scheduler.new
+    now = DateTime.parse("2022-11-29 12:30 +00:00")
+    scheduling_cards = scheduler.repeat(Fsrs::Card.new, now)
+
+    assert_in_delta 60, seconds_between(now, scheduling_cards[Fsrs::Rating::AGAIN].card.due), 0.001
+    assert_in_delta 5.minutes, seconds_between(now, scheduling_cards[Fsrs::Rating::HARD].card.due), 0.001
+    assert_in_delta 10.minutes, seconds_between(now, scheduling_cards[Fsrs::Rating::GOOD].card.due), 0.001
+  end
+
+  private
+
+  def seconds_between(start_time, end_time)
+    (end_time - start_time) * 24 * 60 * 60
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+require "simplecov"
+
+SimpleCov.external_at_exit = true
+SimpleCov.start do
+  root File.expand_path("..", __dir__)
+
+  add_filter "/test/"
+  enable_coverage :branch
+end
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "fsrs"
 


### PR DESCRIPTION
## Summary
- Fix new-card learning steps so Again, Hard, and Good schedule in seconds/minutes instead of days
- Add a regression test for the new-card due date deltas
- Add SimpleCov coverage reporting
- Bump the gem version to 0.9.2

This supersedes the fixes proposed in #9 and #11.

## Verification
- bundle exec rake test
- BUNDLE_GEMFILE=gemfiles/activesupport_7.gemfile bundle exec rake test
- BUNDLE_GEMFILE=gemfiles/activesupport_8.gemfile bundle exec rake test
- bundle exec rubocop
- bundle exec rake build
- Rails 8 smoke app: rails runner and zeitwerk:check